### PR TITLE
Fixed value-rounding for @2x+ devices

### DIFF
--- a/MCUIViewLayout/MCUIViewLayoutPosition.h
+++ b/MCUIViewLayout/MCUIViewLayoutPosition.h
@@ -79,4 +79,7 @@ typedef NS_OPTIONS(NSInteger, MCViewPosition) {
 
 + (CGRect)relativePositionRect:(CGRect)rect atPosition:(MCViewPosition)position inRect:(CGRect)targetRect withMargins:(UIEdgeInsets const)margins;
 
++ (CGFloat)ceilFloatToDisplayScale:(CGFloat)number;
++ (CGFloat)floorFloatToDisplayScale:(CGFloat)number;
+
 @end

--- a/MCUIViewLayout/MCUIViewLayoutPosition.m
+++ b/MCUIViewLayout/MCUIViewLayoutPosition.m
@@ -36,8 +36,8 @@
 + (CGSize)sizeForPosition:(MCViewPosition)position andInset:(UIEdgeInsets)inset initialSize:(CGSize)size inRect:(CGRect)rect
 {
     CGSize result = size;
-    result.width = [self ceilFloatIfRequired:[self widthForPosition:position andInset:inset initialSize:size inRect:rect]];
-    result.height = [self ceilFloatIfRequired:[self heightForPosition:position andInset:inset initialSize:size inRect:rect]];
+    result.width = [self ceilFloatToDisplayScale:[self widthForPosition:position andInset:inset initialSize:size inRect:rect]];
+    result.height = [self ceilFloatToDisplayScale:[self heightForPosition:position andInset:inset initialSize:size inRect:rect]];
     return result;
 }
 
@@ -63,17 +63,17 @@
     CGPoint origin = CGPointZero;
 
     if ((position & MCViewPositionLeft) || (position & MCViewPositionToTheRight)){
-        origin.x = [self floorFloatIfRequired:[self xOriginForPosition:position andInset:inset size:size inRect:targetRect defaultX:initialRectOrigin.x]];
+        origin.x = [self floorFloatToDisplayScale:[self xOriginForPosition:position andInset:inset size:size inRect:targetRect defaultX:initialRectOrigin.x]];
     }
     else {
-        origin.x = [self ceilFloatIfRequired:[self xOriginForPosition:position andInset:inset size:size inRect:targetRect defaultX:initialRectOrigin.x]];
+        origin.x = [self ceilFloatToDisplayScale:[self xOriginForPosition:position andInset:inset size:size inRect:targetRect defaultX:initialRectOrigin.x]];
     }
 
     if ((position & MCViewPositionTop) || (position & MCViewPositionUnder)) {
-        origin.y = [self floorFloatIfRequired:[self yOriginForPosition:position andInset:inset size:size inRect:targetRect defaultY:initialRectOrigin.y]];
+        origin.y = [self floorFloatToDisplayScale:[self yOriginForPosition:position andInset:inset size:size inRect:targetRect defaultY:initialRectOrigin.y]];
     }
     else {
-        origin.y = [self ceilFloatIfRequired:[self yOriginForPosition:position andInset:inset size:size inRect:targetRect defaultY:initialRectOrigin.y]];
+        origin.y = [self ceilFloatToDisplayScale:[self yOriginForPosition:position andInset:inset size:size inRect:targetRect defaultY:initialRectOrigin.y]];
     }
 
     return origin;
@@ -176,34 +176,38 @@
     return yPosition;
 }
 
-+ (CGFloat)ceilFloatIfRequired:(CGFloat)number {
++ (CGFloat)ceilFloatToDisplayScale:(CGFloat)number {
     static BOOL onNonRetina;
+    static CGFloat displayScale;
     static dispatch_once_t once;
     dispatch_once(&once, ^ {
-        onNonRetina = [UIScreen mainScreen].scale <= 1.0000f;
+        displayScale = [UIScreen mainScreen].scale;
+        onNonRetina = displayScale <= 1.0000f;
     });
 
     if (onNonRetina) {
         return ceilf(number);
     }
     else {
-        return number;
+        return ceilf(number * displayScale) / displayScale;
     }
 }
 
-+ (CGFloat)floorFloatIfRequired:(CGFloat)number
++ (CGFloat)floorFloatToDisplayScale:(CGFloat)number
 {
     static BOOL onNonRetina;
+    static CGFloat displayScale;
     static dispatch_once_t once;
     dispatch_once(&once, ^ {
-        onNonRetina = [UIScreen mainScreen].scale <= 1.0000f;
+        displayScale = [UIScreen mainScreen].scale;
+        onNonRetina = displayScale <= 1.0000f;
     });
 
     if (onNonRetina) {
         return floorf(number);
     }
     else {
-        return number;
+        return floorf(number * displayScale) / displayScale;
     }
 }
 

--- a/MCUIViewLayout/MCUIViewLayoutPosition.m
+++ b/MCUIViewLayout/MCUIViewLayoutPosition.m
@@ -27,6 +27,30 @@
 #import "MCUIViewLayoutPosition.h"
 
 @implementation MCUIViewLayoutPosition 
+CGFloat (^_ceilFloatToDisplayScale)(CGFloat x);
+CGFloat (^_floorFloatToDisplayScale)(CGFloat x);
+
++ (void)load {
+    CGFloat displayScale = [UIScreen mainScreen].scale;
+    CGFloat displayScaleInv = 1.0f / displayScale;
+    
+    if (displayScale > 1.0f) {
+        _ceilFloatToDisplayScale = ^(CGFloat x) {
+            return ceilf(x * displayScale) * displayScaleInv;
+        };
+        _floorFloatToDisplayScale = ^(CGFloat x) {
+            return floorf(x * displayScale) * displayScaleInv;
+        };
+    } else {
+        _ceilFloatToDisplayScale = ^(CGFloat x) {
+            return (CGFloat)ceilf(x);
+        };
+        _floorFloatToDisplayScale = ^(CGFloat x) {
+            return (CGFloat)floorf(x);
+        };
+    }
+}
+
 + (CGRect)positionRect:(CGRect)rect atPosition:(MCViewPosition)position inRect:(CGRect)targetRect withMargins:(UIEdgeInsets const)margins {
     rect.size = [self sizeForPosition:position andInset:margins initialSize:rect.size inRect:targetRect];
     rect.origin = [self originForPosition:position andInset:margins size:rect.size inRect:targetRect initialRectOrigin:rect.origin];
@@ -36,8 +60,8 @@
 + (CGSize)sizeForPosition:(MCViewPosition)position andInset:(UIEdgeInsets)inset initialSize:(CGSize)size inRect:(CGRect)rect
 {
     CGSize result = size;
-    result.width = [self ceilFloatToDisplayScale:[self widthForPosition:position andInset:inset initialSize:size inRect:rect]];
-    result.height = [self ceilFloatToDisplayScale:[self heightForPosition:position andInset:inset initialSize:size inRect:rect]];
+    result.width = _ceilFloatToDisplayScale([self widthForPosition:position andInset:inset initialSize:size inRect:rect]);
+    result.height = _ceilFloatToDisplayScale([self heightForPosition:position andInset:inset initialSize:size inRect:rect]);
     return result;
 }
 
@@ -63,17 +87,17 @@
     CGPoint origin = CGPointZero;
 
     if ((position & MCViewPositionLeft) || (position & MCViewPositionToTheRight)){
-        origin.x = [self floorFloatToDisplayScale:[self xOriginForPosition:position andInset:inset size:size inRect:targetRect defaultX:initialRectOrigin.x]];
+        origin.x = _floorFloatToDisplayScale([self xOriginForPosition:position andInset:inset size:size inRect:targetRect defaultX:initialRectOrigin.x]);
     }
     else {
-        origin.x = [self ceilFloatToDisplayScale:[self xOriginForPosition:position andInset:inset size:size inRect:targetRect defaultX:initialRectOrigin.x]];
+        origin.x = _ceilFloatToDisplayScale([self xOriginForPosition:position andInset:inset size:size inRect:targetRect defaultX:initialRectOrigin.x]);
     }
 
     if ((position & MCViewPositionTop) || (position & MCViewPositionUnder)) {
-        origin.y = [self floorFloatToDisplayScale:[self yOriginForPosition:position andInset:inset size:size inRect:targetRect defaultY:initialRectOrigin.y]];
+        origin.y = _floorFloatToDisplayScale([self yOriginForPosition:position andInset:inset size:size inRect:targetRect defaultY:initialRectOrigin.y]);
     }
     else {
-        origin.y = [self ceilFloatToDisplayScale:[self yOriginForPosition:position andInset:inset size:size inRect:targetRect defaultY:initialRectOrigin.y]];
+        origin.y = _ceilFloatToDisplayScale([self yOriginForPosition:position andInset:inset size:size inRect:targetRect defaultY:initialRectOrigin.y]);
     }
 
     return origin;
@@ -177,38 +201,11 @@
 }
 
 + (CGFloat)ceilFloatToDisplayScale:(CGFloat)number {
-    static BOOL onNonRetina;
-    static CGFloat displayScale;
-    static dispatch_once_t once;
-    dispatch_once(&once, ^ {
-        displayScale = [UIScreen mainScreen].scale;
-        onNonRetina = displayScale <= 1.0000f;
-    });
-
-    if (onNonRetina) {
-        return ceilf(number);
-    }
-    else {
-        return ceilf(number * displayScale) / displayScale;
-    }
+    return _ceilFloatToDisplayScale(number);
 }
 
-+ (CGFloat)floorFloatToDisplayScale:(CGFloat)number
-{
-    static BOOL onNonRetina;
-    static CGFloat displayScale;
-    static dispatch_once_t once;
-    dispatch_once(&once, ^ {
-        displayScale = [UIScreen mainScreen].scale;
-        onNonRetina = displayScale <= 1.0000f;
-    });
-
-    if (onNonRetina) {
-        return floorf(number);
-    }
-    else {
-        return floorf(number * displayScale) / displayScale;
-    }
++ (CGFloat)floorFloatToDisplayScale:(CGFloat)number {
+    return _floorFloatToDisplayScale(number);
 }
 
 + (CGRect)relativePositionRect:(CGRect)rect atPosition:(MCViewPosition)position inRect:(CGRect)targetRect withMargins:(UIEdgeInsets)margins {


### PR DESCRIPTION
## Problem
The methods `ceilFloatIfRequired` and `floorFloatIfRequired` were only aligning coordinates to the display grid for **@1x** devices, by rounding values to whole pixels.

For **@2x** and **@3x** devices, the views still need to be aligned to the grid, otherwise they may look blurry. The alignment is made to **half** and **third** of pixels, respectively (`0.5` and `0.3333` steps).

## Solution
I changed these two methods to round the values intelligently, and renamed them accordingly (`ceilFloatToDisplayScale` and `floorFloatToDisplayScale`).

I just wanted to validate the strategy used: multiplying by the ratio before rounding and dividing afterwards might be an expensive operation, though I couldn't find a more appropriate solution.

> **Note:** I still kept the `onNonRetina` validation to prevent doing `round(x * 1.0f) / 1.0f` uselessly, especially since non-retina devices *should technically* be the least performant.