### PR TITLE
Fix grid snapping when setting size and origin

### DIFF
--- a/MCUIViewLayout/MCUIViewLayoutPosition.h
+++ b/MCUIViewLayout/MCUIViewLayoutPosition.h
@@ -87,6 +87,8 @@ typedef NS_OPTIONS(NSInteger, MCViewPosition) {
 
 + (CGFloat)ceilFloatToDisplayScale:(CGFloat)number;
 
++ (CGFloat)roundFloatToDisplayScale:(CGFloat)number;
+
 + (CGFloat)floorFloatToDisplayScale:(CGFloat)number;
 
 @end

--- a/MCUIViewLayout/MCUIViewLayoutPosition.m
+++ b/MCUIViewLayout/MCUIViewLayoutPosition.m
@@ -29,7 +29,7 @@
 
 @implementation MCUIViewLayoutPosition
 CGFloat (^_ceilFloatToDisplayScale)(CGFloat x);
-
+CGFloat (^_roundFloatToDisplayScale)(CGFloat x);
 CGFloat (^_floorFloatToDisplayScale)(CGFloat x);
 
 + (void)load {
@@ -40,12 +40,18 @@ CGFloat (^_floorFloatToDisplayScale)(CGFloat x);
         _ceilFloatToDisplayScale = ^(CGFloat x) {
             return ceilf(x * displayScale) * displayScaleInv;
         };
+        _roundFloatToDisplayScale = ^(CGFloat x) {
+            return roundf(x * displayScale) * displayScaleInv;
+        };
         _floorFloatToDisplayScale = ^(CGFloat x) {
             return floorf(x * displayScale) * displayScaleInv;
         };
     } else {
         _ceilFloatToDisplayScale = ^(CGFloat x) {
             return (CGFloat)ceilf(x);
+        };
+        _roundFloatToDisplayScale = ^(CGFloat x) {
+            return (CGFloat)roundf(x);
         };
         _floorFloatToDisplayScale = ^(CGFloat x) {
             return (CGFloat)floorf(x);
@@ -200,6 +206,10 @@ CGFloat (^_floorFloatToDisplayScale)(CGFloat x);
 
 + (CGFloat)ceilFloatToDisplayScale:(CGFloat)number {
     return _ceilFloatToDisplayScale(number);
+}
+
++ (CGFloat)roundFloatToDisplayScale:(CGFloat)number {
+    return _roundFloatToDisplayScale(number);
 }
 
 + (CGFloat)floorFloatToDisplayScale:(CGFloat)number {

--- a/MCUIViewLayout/UIView+MCLayout.m
+++ b/MCUIViewLayout/UIView+MCLayout.m
@@ -25,6 +25,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#import "MCUIViewLayoutPosition.h"
 #import "UIView+MCLayout.h"
 #import "UIView+MCLayoutCalculation.h"
 
@@ -35,7 +36,7 @@
 
 - (void)mc_setWidth:(CGFloat)value {
     CGRect frame = [self frame];
-    frame.size.width = ceilf(value);
+    frame.size.width = [MCUIViewLayoutPosition ceilFloatToDisplayScale:value];
     [self setFrame:frame];
 }
 
@@ -45,14 +46,14 @@
 
 - (void)mc_setHeight:(CGFloat)value {
     CGRect frame = [self frame];
-    frame.size.height = ceilf(value);
+    frame.size.height = [MCUIViewLayoutPosition ceilFloatToDisplayScale:value];
     [self setFrame:frame];
 }
 
 - (void)mc_setSize:(CGSize)size {
     CGRect frame = [self frame];
-    frame.size.width = ceilf(size.width);
-    frame.size.height = ceilf(size.height);
+    frame.size.width = [MCUIViewLayoutPosition ceilFloatToDisplayScale:size.width];
+    frame.size.height = [MCUIViewLayoutPosition ceilFloatToDisplayScale:size.height];
     [self setFrame:frame];
 }
 
@@ -67,7 +68,7 @@
 
 - (void)mc_setOrigin:(CGPoint)point {
     CGRect frame = [self frame];
-    frame.origin = CGPointMake(roundf(point.x), roundf(point.y));
+    frame.origin = CGPointMake([MCUIViewLayoutPosition roundFloatToDisplayScale:point.x], [MCUIViewLayoutPosition roundFloatToDisplayScale:point.y]);
     [self setFrame:frame];
 }
 

--- a/MCUIViewLayoutExample/UIViewLayoutExampleTests/UIView_MCLayoutSizeAndPositionBaseMethodTest.m
+++ b/MCUIViewLayoutExample/UIViewLayoutExampleTests/UIView_MCLayoutSizeAndPositionBaseMethodTest.m
@@ -36,6 +36,12 @@
 
 @implementation UIView_MCLayoutSizeAndPositionBaseMethodTest
 
+CGFloat onePixel;
+
++ (void)load {
+    onePixel = 1.0f / [UIScreen mainScreen].scale;
+}
+
 - (void)setUp {
     [super setUp];
     self.containerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)];
@@ -62,7 +68,9 @@
 
 - (void)testMCSetSizeWithDecimalDimensionsBelowPointFiveShouldCeilToTheHighestValue {
     [self.toMesureView mc_setSize:CGSizeMake(50.04, 50.6)];
-    XCTAssertTrue(sizeEquals(51, 51, [self.toMesureView mc_size]), @"");
+    CGFloat newWidth = ceilf(50.04 / onePixel) * onePixel;
+    CGFloat newHeight = ceilf(50.6 / onePixel) * onePixel;
+    XCTAssertTrue(sizeEquals(newWidth, newHeight, [self.toMesureView mc_size]), @"");
 }
 
 - (void)testMCGetHeight {
@@ -77,7 +85,7 @@
 
 - (void)testMCSetHeightWithDecimalDimensionsBelowPointFiveShouldCeilToTheHighestValue {
     [self.toMesureView mc_setHeight:46.001f];
-    XCTAssertEqual(47.0f, [self.toMesureView mc_height], @"");
+    XCTAssertEqual(46.0f + onePixel, [self.toMesureView mc_height], @"");
 }
 
 - (void)testMCGetWidth {
@@ -92,7 +100,7 @@
 
 - (void)testMCSetWidthWithDecimalDimensionsBelowPointFiveShouldCeilToTheHighestValue {
     [self.toMesureView mc_setWidth:46.001f];
-    XCTAssertEqual(47.0f, [self.toMesureView mc_width], @"");
+    XCTAssertEqual(46.0f + onePixel, [self.toMesureView mc_width], @"");
 }
 
 - (void)testMCGetOrigin {


### PR DESCRIPTION
This fixes rounding functions that weren't considering device resolution in `mc_setSize`, `mc_setHeight`, `mc_setWidth` and `mc_setOrigin`.