### PR TITLE
Swift wrapper for MCUIViewLayout

### DIFF
--- a/MCUIViewLayout/UIView+MCLayout.swift
+++ b/MCUIViewLayout/UIView+MCLayout.swift
@@ -1,0 +1,153 @@
+// Copyright (c) 2016, Mirego
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// - Neither the name of the Mirego nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import UIKit
+
+/**
+ Swift wrapper for MCUIViewLayout
+ 
+ Features:
+    * Simplified syntaxe, remove all “mc_()”
+    * Many view properties are exposed as variable in Swift:
+         - width: CGFloat     [read-write]
+         - height: CGFloat    [read-write]
+         - size: CGSize       [read-write]
+         - origin: CGPoint    [read-write]
+         - xPosition: CGFloat [read only]
+         - yPosition: CGFloat [read only]
+         - maxX: CGFloat      [read only]
+         - maxY: CGFloat      [read only]
+         - minX: CGFloat      [read only]
+         - minY: CGFloat      [read only]
+         - midX: CGFloat      [read only]
+         - midY: CGFloat      [read only]
+
+        Examples:
+            myChild.size = view.size
+            myChild.width = view.width
+
+    * Only expose two methods to position UIView easily:  setPosition() and setRelativePosition()
+            Optional parameters: margins and size parameters are optionals, so they can be omitted.
+
+        Examples:
+            myChild.setPosition(.PositionTopHCenter)
+            myChild.setPosition(.PositionTopHCenter, size: CGSize(width: 10, height: 10))
+            myChild.setPosition(.PositionTopLeft, size: CGSize(width: parentView.width / 2, height: parentView.height / 2))
+ 
+            myChild.setRelativePosition(.RelativePositionUnderCentered, toView: previousView, margins: UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0))
+*/
+extension UIView
+{
+    var width: CGFloat {
+        set {
+            mc_setWidth(newValue)
+        }
+
+        get {
+            return bounds.width
+        }
+    }
+
+    var height: CGFloat {
+        set {
+            mc_setHeight(newValue)
+        }
+
+        get {
+            return bounds.height
+        }
+    }
+
+    var size: CGSize {
+        set {
+            mc_setSize(newValue)
+        }
+
+        get {
+            return bounds.size
+        }
+    }
+
+    var origin: CGPoint {
+        set {
+            mc_setOrigin(newValue)
+        }
+
+        get {
+            return frame.origin
+        }
+    }
+
+    var xPosition: CGFloat {
+        return frame.origin.x
+    }
+
+    var yPosition: CGFloat {
+        return frame.origin.y
+    }
+
+    var maxX: CGFloat {
+        return frame.maxX
+    }
+
+    var maxY: CGFloat {
+        return frame.maxY
+    }
+
+    var minX: CGFloat {
+        return frame.minX
+    }
+
+    var minY: CGFloat {
+        return frame.minY
+    }
+
+    var midX: CGFloat {
+        return frame.midX
+    }
+
+    var midY: CGFloat {
+        return frame.midY
+    }
+
+    func setPosition(position: MCViewPosition, inView: UIView? = nil, margins: UIEdgeInsets? = nil, size: CGSize? = nil)
+    {
+        let inView = inView ?? superview
+        let margins = margins ?? UIEdgeInsetsZero
+        let size = size ?? frame.size
+
+        mc_setPosition(position, inView:inView, withMargins: margins, size:size)
+    }
+
+    func setRelativePosition(position: MCViewPosition, toView: UIView?, margins: UIEdgeInsets? = nil, size: CGSize? = nil)
+    {
+        let margins = margins ?? UIEdgeInsetsZero
+        let size = size ?? frame.size
+
+        mc_setRelativePosition(position, toView:toView, withMargins: margins, size:size)
+    }
+}

--- a/MCUIViewLayout/UIView+MCLayout.swift
+++ b/MCUIViewLayout/UIView+MCLayout.swift
@@ -31,8 +31,8 @@ import UIKit
  Swift wrapper for MCUIViewLayout
  
  Features:
-    * Simplified syntaxe, remove all “mc_()”
-    * Many view properties are exposed as variable in Swift:
+    * Simplified syntax compare to objective-c (remove all “mc_()”)
+    * Many UIView properties are exposed as variable in Swift:
          - width: CGFloat     [read-write]
          - height: CGFloat    [read-write]
          - size: CGSize       [read-write]

--- a/MCUIViewLayout/UIView-Bridging-Header.h
+++ b/MCUIViewLayout/UIView-Bridging-Header.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, Mirego
+// Copyright (c) 2016, Mirego
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -25,13 +25,4 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#import <Foundation/Foundation.h>
-
-@interface MCUIViewLayoutExampleMenuView : UIView
-@property (nonatomic, readonly) UIButton *buttonSetPosition;
-@property (nonatomic, readonly) UIButton *buttonSetPositionSwift;
-@property (nonatomic, readonly) UIButton *buttonSetRelativePosition;
-@property (nonatomic, readonly) UIButton *buttonSetPositionSizeToFit;
-@property (nonatomic, readonly) UIButton *buttonSpecialCases;
-@property (nonatomic, readonly) UIButton *buttonRelativeCenterInParent;
-@end
+#import "UIView+MCLayout.h"

--- a/MCUIViewLayoutExample/UIViewLayoutExample.xcodeproj/project.pbxproj
+++ b/MCUIViewLayoutExample/UIViewLayoutExample.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		B89DB36EDFD64CFC8C7A6A7D /* UIView_MCLayoutPositionAlignInSuperViewTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B89DBAECC0EB0C068FBE5262 /* UIView_MCLayoutPositionAlignInSuperViewTest.m */; };
 		B89DBE02216348FB5B9EA7A3 /* UIView_MCLayoutCalculationsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B89DBD3A820285898C6E33C8 /* UIView_MCLayoutCalculationsTest.m */; };
 		BF930920665F2EF890D53326 /* MCUIViewLayoutPosition.m in Sources */ = {isa = PBXBuildFile; fileRef = BF93017C2A02E04CC15591BF /* MCUIViewLayoutPosition.m */; };
+		DF05FD5B1C6A5BDD00CA825F /* UIView+MCLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF05FD5A1C6A5BDD00CA825F /* UIView+MCLayout.swift */; };
+		DF05FD5D1C6A5D0B00CA825F /* MCUIViewLayoutExampleSetPositionSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF05FD5C1C6A5D0B00CA825F /* MCUIViewLayoutExampleSetPositionSwift.swift */; };
 		FA41FEF91703D35100071708 /* UIView+MCLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = FA41FEF81703D35100071708 /* UIView+MCLayout.m */; };
 /* End PBXBuildFile section */
 
@@ -100,6 +102,9 @@
 		BF9303A636A8ECB35132EAAD /* GeometryTestingHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeometryTestingHelper.m; sourceTree = "<group>"; };
 		BF9305FFE48374C7414278C6 /* GeometryTestingHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeometryTestingHelper.h; sourceTree = "<group>"; };
 		BF930D8EB447693A4A094EA0 /* MCUIViewLayoutPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCUIViewLayoutPosition.h; sourceTree = "<group>"; };
+		DF05FD591C6A5BDC00CA825F /* UIView-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView-Bridging-Header.h"; sourceTree = "<group>"; };
+		DF05FD5A1C6A5BDD00CA825F /* UIView+MCLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+MCLayout.swift"; sourceTree = "<group>"; };
+		DF05FD5C1C6A5D0B00CA825F /* MCUIViewLayoutExampleSetPositionSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCUIViewLayoutExampleSetPositionSwift.swift; sourceTree = "<group>"; };
 		FA41FEF71703D35100071708 /* UIView+MCLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+MCLayout.h"; sourceTree = "<group>"; };
 		FA41FEF81703D35100071708 /* UIView+MCLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+MCLayout.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -165,6 +170,7 @@
 				915CCE9B66464E120F02DF6F /* MCUIViewLayoutRootController.h */,
 				915CC9F339EE34C5EFB71925 /* MCUIViewLayoutExampleSetPosition.m */,
 				915CC00B966DD189ED394F8E /* MCUIViewLayoutExampleSetPosition.h */,
+				DF05FD5C1C6A5D0B00CA825F /* MCUIViewLayoutExampleSetPositionSwift.swift */,
 				915CCAFCAE539F379DDA60E1 /* MCUIViewLayoutExampleMenuView.m */,
 				915CCAB334DF61FFB551D7B7 /* MCUIViewLayoutExampleMenuView.h */,
 				915CCB9122A70EB9F47C5BB7 /* MCUIViewLayoutExampleSetRelativePosition.m */,
@@ -220,12 +226,14 @@
 			children = (
 				FA41FEF71703D35100071708 /* UIView+MCLayout.h */,
 				FA41FEF81703D35100071708 /* UIView+MCLayout.m */,
+				DF05FD5A1C6A5BDD00CA825F /* UIView+MCLayout.swift */,
 				BF930D8EB447693A4A094EA0 /* MCUIViewLayoutPosition.h */,
 				BF93017C2A02E04CC15591BF /* MCUIViewLayoutPosition.m */,
 				325169C81BF685D900038FAF /* UIView+MCLayoutCalculation.h */,
 				325169C91BF685D900038FAF /* UIView+MCLayoutCalculation.m */,
 				915CC490438FC7F0C4280A4E /* UIView+MCLayoutDeprecated.m */,
 				915CC5E96A22B9D2595F79FB /* UIView+MCLayoutDeprecated.h */,
+				DF05FD591C6A5BDC00CA825F /* UIView-Bridging-Header.h */,
 			);
 			name = MCUIViewLayout;
 			path = ../MCUIViewLayout;
@@ -275,6 +283,7 @@
 		09ABD57A16E8ECF200290BB3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Mirego, Inc.";
 				TargetAttributes = {
@@ -334,11 +343,13 @@
 				FA41FEF91703D35100071708 /* UIView+MCLayout.m in Sources */,
 				915CC234176C38B004A184DA /* MCUIViewLayoutRootController.m in Sources */,
 				915CCC00441E907727365383 /* MCUIViewLayoutExampleSetPosition.m in Sources */,
+				DF05FD5D1C6A5D0B00CA825F /* MCUIViewLayoutExampleSetPositionSwift.swift in Sources */,
 				915CCA7A367EF8173AB5D7E3 /* MCUIViewLayoutExampleMenuView.m in Sources */,
 				915CCD3D1192C7EE590BBBC3 /* MCUIViewLayoutExampleSetRelativePosition.m in Sources */,
 				915CC1C38A309CC53EF0A7BC /* MCUIViewExampleUIFactory.m in Sources */,
 				BF930920665F2EF890D53326 /* MCUIViewLayoutPosition.m in Sources */,
 				325169CA1BF685D900038FAF /* UIView+MCLayoutCalculation.m in Sources */,
+				DF05FD5B1C6A5BDD00CA825F /* UIView+MCLayout.swift in Sources */,
 				915CC036C17BE1BC5CCE2517 /* UIView+MCLayoutDeprecated.m in Sources */,
 				915CCAB408003F7D205D454C /* MCUIViewLayoutExampleSetPositionSizeToFit.m in Sources */,
 				915CC73967A80F9F4CC9355B /* MCUIViewLayoutExampleSpecialCases.m in Sources */,
@@ -444,12 +455,16 @@
 		09ABD5A016E8ECF300290BB3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "UIViewLayoutExample/UIViewLayoutExample-Prefix.pch";
 				INFOPLIST_FILE = "UIViewLayoutExample/UIViewLayoutExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mirego.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "../MCUIViewLayout/UIView-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
@@ -458,12 +473,15 @@
 		09ABD5A116E8ECF300290BB3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "UIViewLayoutExample/UIViewLayoutExample-Prefix.pch";
 				INFOPLIST_FILE = "UIViewLayoutExample/UIViewLayoutExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mirego.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "../MCUIViewLayout/UIView-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
@@ -593,12 +611,16 @@
 		A6E494671829A93300692FB5 /* Coverage */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "UIViewLayoutExample/UIViewLayoutExample-Prefix.pch";
 				INFOPLIST_FILE = "UIViewLayoutExample/UIViewLayoutExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mirego.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "../MCUIViewLayout/UIView-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};

--- a/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleMenuView.m
+++ b/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleMenuView.m
@@ -33,6 +33,7 @@
 //------------------------------------------------------------------------------
 @interface MCUIViewLayoutExampleMenuView ()
 @property (nonatomic, readwrite) UIButton *buttonSetPosition;
+@property (nonatomic, readwrite) UIButton *buttonSetPositionSwift;
 @property (nonatomic, readwrite) UIButton *buttonSetRelativePosition;
 @property (nonatomic, readwrite) UIButton *buttonSetPositionSizeToFit;
 @property (nonatomic, readwrite) UIButton *buttonSpecialCases;
@@ -51,10 +52,18 @@
 - (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
+        UIColor* swiftColor = [self colorFromHexString:@"#dd4d20"];
+
         self.buttonSetPosition = [UIButton buttonWithType:UIButtonTypeRoundedRect];
         [self.buttonSetPosition setTitle:@"mc_setPosition" forState:UIControlStateNormal];
         [self.buttonSetPosition sizeToFit];
         [self addSubview:self.buttonSetPosition];
+
+        self.buttonSetPositionSwift = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+        [self.buttonSetPositionSwift setTitle:@"setPosition [Swift]" forState:UIControlStateNormal];
+        [self.buttonSetPositionSwift setTitleColor:swiftColor  forState:UIControlStateNormal];
+        [self.buttonSetPositionSwift sizeToFit];
+        [self addSubview:self.buttonSetPositionSwift];
 
         self.buttonSetRelativePosition = [UIButton buttonWithType:UIButtonTypeRoundedRect];
         [self.buttonSetRelativePosition setTitle:@"mc_setPositionRelative" forState:UIControlStateNormal];
@@ -95,8 +104,11 @@
     [super layoutSubviews];
     [self.buttonSetPosition mc_setPosition:MCViewPositionTopHCenter withMargins:UIEdgeInsetsMake(50, 0, 0, 0)];
 
+    [self.buttonSetPositionSwift mc_setRelativePosition:MCViewRelativePositionUnderCentered
+                                                    toView:self.buttonSetPosition withMargins:UIEdgeInsetsZero];
+
     [self.buttonSetRelativePosition mc_setRelativePosition:MCViewRelativePositionUnderCentered
-                                                    toView:self.buttonSetPosition withMargins:UIEdgeInsetsMake(15.0f, 0, 0, 0)];
+                                                    toView:self.buttonSetPositionSwift withMargins:UIEdgeInsetsMake(15.0f, 0, 0, 0)];
 
     [self.buttonSetPositionSizeToFit mc_setRelativePosition:MCViewRelativePositionUnderCentered
                                                      toView:self.buttonSetRelativePosition withMargins:UIEdgeInsetsMake(15.0f, 0, 0, 0)];
@@ -120,5 +132,13 @@
 //------------------------------------------------------------------------------
 #pragma mark Private methods
 //------------------------------------------------------------------------------
+
+- (UIColor *)colorFromHexString:(NSString *)hexString {
+    unsigned rgbValue = 0;
+    NSScanner *scanner = [NSScanner scannerWithString:hexString];
+    [scanner setScanLocation:1]; // bypass '#' character
+    [scanner scanHexInt:&rgbValue];
+    return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+}
 
 @end

--- a/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleMenuView.m
+++ b/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleMenuView.m
@@ -52,8 +52,6 @@
 - (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        UIColor* swiftColor = [self colorFromHexString:@"#dd4d20"];
-
         self.buttonSetPosition = [UIButton buttonWithType:UIButtonTypeRoundedRect];
         [self.buttonSetPosition setTitle:@"mc_setPosition" forState:UIControlStateNormal];
         [self.buttonSetPosition sizeToFit];
@@ -61,7 +59,7 @@
 
         self.buttonSetPositionSwift = [UIButton buttonWithType:UIButtonTypeRoundedRect];
         [self.buttonSetPositionSwift setTitle:@"setPosition [Swift]" forState:UIControlStateNormal];
-        [self.buttonSetPositionSwift setTitleColor:swiftColor  forState:UIControlStateNormal];
+        [self.buttonSetPositionSwift setTitleColor:[UIColor orangeColor] forState:UIControlStateNormal];
         [self.buttonSetPositionSwift sizeToFit];
         [self addSubview:self.buttonSetPositionSwift];
 
@@ -132,13 +130,5 @@
 //------------------------------------------------------------------------------
 #pragma mark Private methods
 //------------------------------------------------------------------------------
-
-- (UIColor *)colorFromHexString:(NSString *)hexString {
-    unsigned rgbValue = 0;
-    NSScanner *scanner = [NSScanner scannerWithString:hexString];
-    [scanner setScanLocation:1]; // bypass '#' character
-    [scanner scanHexInt:&rgbValue];
-    return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
-}
 
 @end

--- a/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleSetPositionSwift.swift
+++ b/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleSetPositionSwift.swift
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, Mirego
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// - Neither the name of the Mirego nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+class MCUIViewLayoutExampleSetPositionSwift: UIView
+{
+    private let margin: CGFloat = 10
+
+    private let topLeft = UILabel()
+    private let top = UILabel()
+    private let topRight = UILabel()
+    private let left = UILabel()
+    private let centered = UILabel()
+    private let right = UILabel()
+    private let bottomLeft = UILabel()
+    private let bottom = UILabel()
+    private let bottomRight = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = .blueColor()
+
+        addLabel(topLeft, title: "topLeft")
+        addLabel(top, title: "top")
+        addLabel(topRight, title: "topRight")
+        addLabel(left, title: "left")
+        addLabel(centered, title: "centered")
+        addLabel(right, title: "right")
+
+        addLabel(bottomLeft, title: "bottomLeft")
+        addLabel(bottom, title: "bottom")
+        addLabel(bottomRight, title: "bottomRight")
+
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: "close"))
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let margins = UIEdgeInsets(top: margin, left: margin, bottom: margin, right: margin)
+
+        topLeft.setPosition(.PositionTopLeft, margins: margins)
+        top.setPosition(.PositionTopHCenter, margins: margins)
+        topRight.setPosition(.PositionTopRight, margins: margins)
+        left.setPosition(.PositionVCenterLeft, margins: margins)
+        centered.setPosition(.PositionCenters, margins: margins)
+        right.setPosition(.PositionVCenterRight, margins: margins)
+        bottomLeft.setPosition(.PositionBottomLeft, margins: margins)
+        bottom.setPosition(.PositionBottomHCenter, margins: margins)
+        bottomRight.setPosition(.PositionBottomRight, margins: margins)
+    }
+
+    private func addLabel(label: UILabel, title: String) {
+        label.text = title
+        label.textAlignment = .Center
+        label.sizeToFit()
+
+        addSubview(label)
+    }
+
+    func close() {
+        removeFromSuperview()
+    }
+}

--- a/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleSetPositionSwift.swift
+++ b/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleSetPositionSwift.swift
@@ -60,7 +60,7 @@ class MCUIViewLayoutExampleSetPositionSwift: UIView
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: "close"))
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    required init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutRootController.m
+++ b/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutRootController.m
@@ -25,6 +25,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#import <UIViewLayoutExample-Swift.h>
+
 #import "MCUIViewLayoutRootController.h"
 #import "MCUIViewLayoutExampleSetPosition.h"
 #import "MCUIViewLayoutExampleMenuView.h"
@@ -68,6 +70,8 @@
 - (void)loadView {
     MCUIViewLayoutExampleMenuView *rootview = [[MCUIViewLayoutExampleMenuView alloc] initWithFrame:[[UIScreen mainScreen] applicationFrame]];
     [rootview.buttonSetPosition addTarget:self action:@selector(showSetPositionExample) forControlEvents:UIControlEventTouchUpInside];
+    [rootview.buttonSetPositionSwift addTarget:self action:@selector(showSetPositionExampleSwift) forControlEvents:UIControlEventTouchUpInside];
+
     [rootview.buttonSetRelativePosition addTarget:self action:@selector(showSetRelativePositionExample) forControlEvents:UIControlEventTouchUpInside];
     [rootview.buttonSetPositionSizeToFit addTarget:self action:@selector(showSetPositionSizeToFitExample) forControlEvents:UIControlEventTouchUpInside];
     [rootview.buttonSpecialCases addTarget:self action:@selector(showSpecialCases) forControlEvents:UIControlEventTouchUpInside];
@@ -83,6 +87,12 @@
 
 - (void)showSetPositionExample {
     UIView *view = [[MCUIViewLayoutExampleSetPosition alloc] initWithFrame:self.view.bounds];
+    view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.view addSubview:view];
+}
+
+- (void)showSetPositionExampleSwift {
+    UIView *view = [[MCUIViewLayoutExampleSetPositionSwift alloc] initWithFrame:self.view.bounds];
     view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self.view addSubview:view];
 }


### PR DESCRIPTION
Changes:
* Add Swift wrapper
* Add a example screen in the test app (setPosition [Swift]). Other pages should eventually be added)

 Features:
    * Simplified syntax compare to objective-c (remove all “mc_()”)
    * Many UIView properties are exposed as variable in Swift:
         - width: CGFloat     [read-write]
         - height: CGFloat    [read-write]
         - size: CGSize       [read-write]
         - origin: CGPoint    [read-write]
         - xPosition: CGFloat [read only]
         - yPosition: CGFloat [read only]
         - maxX: CGFloat      [read only]
         - maxY: CGFloat      [read only]
         - minX: CGFloat      [read only]
         - minY: CGFloat      [read only]
         - midX: CGFloat      [read only]
         - midY: CGFloat      [read only]

        Examples:
            myChild.size = view.size
            myChild.width = view.width

    * Only expose two methods to position UIView easily:  setPosition() and setRelativePosition()
            Optional parameters: margins and size parameters are optionals, so they can be omitted.

        Examples:
            myChild.setPosition(.PositionTopHCenter)
            myChild.setPosition(.PositionTopHCenter, size: CGSize(width: 10, height: 10))
            myChild.setPosition(.PositionTopLeft, size: CGSize(width: parentView.width / 2, height: parentView.height / 2))
           myChild.setRelativePosition(.RelativePositionUnderCentered, toView: previousView, margins: UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0))


![simulator screen shot feb 9 2016 13 39 11](https://cloud.githubusercontent.com/assets/14981341/12926671/8fa835ae-cf32-11e5-8414-8b5545d67fef.png)
