### PR TITLE
Update MCUIViewLayout's Swift extension: Add optional "fitSize" parameter to setPosition/setRelativePosition methods

### DIFF
--- a/MCUIViewLayout/UIView+MCLayout.swift
+++ b/MCUIViewLayout/UIView+MCLayout.swift
@@ -50,15 +50,7 @@ import UIKit
             myChild.size = view.size
             myChild.width = view.width
 
-    * Only expose two methods to position UIView easily:  setPosition() and setRelativePosition()
-            Optional parameters: margins and size parameters are optionals, so they can be omitted.
-
-        Examples:
-            myChild.setPosition(.PositionTopHCenter)
-            myChild.setPosition(.PositionTopHCenter, size: CGSize(width: 10, height: 10))
-            myChild.setPosition(.PositionTopLeft, size: CGSize(width: parentView.width / 2, height: parentView.height / 2))
- 
-            myChild.setRelativePosition(.RelativePositionUnderCentered, toView: previousView, margins: UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0))
+    * Expose two methods to position UIView easily: setPosition() and setRelativePosition()
 */
 extension UIView
 {
@@ -134,20 +126,62 @@ extension UIView
         return frame.midY
     }
 
-    func setPosition(position: MCViewPosition, inView: UIView? = nil, margins: UIEdgeInsets? = nil, size: CGSize? = nil)
+    /**
+     Position the view
+
+     - parameter position: see MCViewPosition
+     - parameter inView:   Optional relative view. Default value is view's superview.
+     - parameter margins:  Optional margins.
+     - parameter size:     Optional view new size. By default keeps the current view size.
+     - parameter fitSize:  Optional size to fit. If specified the view sizeThatFits() method will be called using the specified size and the result
+                           will be use to set the view size.
+     
+     Examples:
+         myChild.setPosition(.PositionTopHCenter)
+         myChild.setPosition(.PositionTopHCenter, size: CGSize(width: 200, height: 40))
+         myChild.setPosition(.PositionTopLeft, size: CGSize(width: width / 2, height: height / 2))
+         myChild.setPosition(.PositionTopLeft, fitSize: CGSize(width: width, height: .max))
+     */
+    func setPosition(position: MCViewPosition, inView: UIView? = nil, margins: UIEdgeInsets? = nil, size: CGSize? = nil, fitSize: CGSize? = nil)
     {
         let inView = inView ?? superview
         let margins = margins ?? UIEdgeInsetsZero
-        let size = size ?? frame.size
+        var size = size
 
-        mc_setPosition(position, inView:inView, withMargins: margins, size:size)
+        if let fitSize = fitSize {
+            assert(size == nil, "If 'fitSize' param is specified, 'size' param will be ignored!")
+            size = sizeThatFits(fitSize)
+        }
+
+        mc_setPosition(position, inView:inView, withMargins: margins, size: size ?? frame.size)
     }
 
-    func setRelativePosition(position: MCViewPosition, toView: UIView?, margins: UIEdgeInsets? = nil, size: CGSize? = nil)
+    /**
+     Position the view relative to another view.
+
+     - parameter position: see MCViewPosition
+     - parameter toView:   The view from which the view will be relatively positioned.
+     - parameter margins:  Optional margins.
+     - parameter size:     Optional view new size. By default keeps the current view size.
+     - parameter fitSize:  Optional size to fit. If specified the view sizeThatFits() method will be called using the specified and the result
+                           will be use to set the view size.
+
+     Examples:
+         myChild.setRelativePosition(.RelativePositionUnderCentered, toView: previousView)
+         myChild.setRelativePosition(.RelativePositionUnderCentered, toView: previousView, size: CGSize(width: 200, height: 40))
+         myChild.setRelativePosition(.RelativePositionUnderCentered, toView: previousView, margins: UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0))
+         myChild.setRelativePosition(.RelativePositionUnderCentered, toView: previousView, fitSize: CGSize(width: width, height: .max))
+     */
+    func setRelativePosition(position: MCViewPosition, toView: UIView?, margins: UIEdgeInsets? = nil, size: CGSize? = nil, fitSize: CGSize? = nil)
     {
         let margins = margins ?? UIEdgeInsetsZero
-        let size = size ?? frame.size
+        var size = size
 
-        mc_setRelativePosition(position, toView:toView, withMargins: margins, size:size)
+        if let fitSize = fitSize {
+            assert(size == nil, "If 'fitSize' param is specified, 'size' param will be ignored!")
+            size = sizeThatFits(fitSize)
+        }
+
+        mc_setRelativePosition(position, toView:toView, withMargins: margins, size: size ?? frame.size)
     }
 }

--- a/MCUIViewLayoutExample/UIViewLayoutExample.xcodeproj/project.pbxproj
+++ b/MCUIViewLayoutExample/UIViewLayoutExample.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		BF930920665F2EF890D53326 /* MCUIViewLayoutPosition.m in Sources */ = {isa = PBXBuildFile; fileRef = BF93017C2A02E04CC15591BF /* MCUIViewLayoutPosition.m */; };
 		DF05FD5B1C6A5BDD00CA825F /* UIView+MCLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF05FD5A1C6A5BDD00CA825F /* UIView+MCLayout.swift */; };
 		DF05FD5D1C6A5D0B00CA825F /* MCUIViewLayoutExampleSetPositionSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF05FD5C1C6A5D0B00CA825F /* MCUIViewLayoutExampleSetPositionSwift.swift */; };
+		DF16A1751CD7C29A00538C7B /* MCUIViewLayoutExampleSetPositionFitSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF16A1741CD7C29A00538C7B /* MCUIViewLayoutExampleSetPositionFitSize.swift */; };
 		FA41FEF91703D35100071708 /* UIView+MCLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = FA41FEF81703D35100071708 /* UIView+MCLayout.m */; };
 /* End PBXBuildFile section */
 
@@ -105,6 +106,7 @@
 		DF05FD591C6A5BDC00CA825F /* UIView-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView-Bridging-Header.h"; sourceTree = "<group>"; };
 		DF05FD5A1C6A5BDD00CA825F /* UIView+MCLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+MCLayout.swift"; sourceTree = "<group>"; };
 		DF05FD5C1C6A5D0B00CA825F /* MCUIViewLayoutExampleSetPositionSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCUIViewLayoutExampleSetPositionSwift.swift; sourceTree = "<group>"; };
+		DF16A1741CD7C29A00538C7B /* MCUIViewLayoutExampleSetPositionFitSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCUIViewLayoutExampleSetPositionFitSize.swift; sourceTree = "<group>"; };
 		FA41FEF71703D35100071708 /* UIView+MCLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+MCLayout.h"; sourceTree = "<group>"; };
 		FA41FEF81703D35100071708 /* UIView+MCLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+MCLayout.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -171,6 +173,7 @@
 				915CC9F339EE34C5EFB71925 /* MCUIViewLayoutExampleSetPosition.m */,
 				915CC00B966DD189ED394F8E /* MCUIViewLayoutExampleSetPosition.h */,
 				DF05FD5C1C6A5D0B00CA825F /* MCUIViewLayoutExampleSetPositionSwift.swift */,
+				DF16A1741CD7C29A00538C7B /* MCUIViewLayoutExampleSetPositionFitSize.swift */,
 				915CCAFCAE539F379DDA60E1 /* MCUIViewLayoutExampleMenuView.m */,
 				915CCAB334DF61FFB551D7B7 /* MCUIViewLayoutExampleMenuView.h */,
 				915CCB9122A70EB9F47C5BB7 /* MCUIViewLayoutExampleSetRelativePosition.m */,
@@ -337,6 +340,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DF16A1751CD7C29A00538C7B /* MCUIViewLayoutExampleSetPositionFitSize.swift in Sources */,
 				09ABD59216E8ECF300290BB3 /* main.m in Sources */,
 				32B134701BFA75010058FB3A /* MCUIViewLayoutExampleRelativeCenterInParent.m in Sources */,
 				09ABD59616E8ECF300290BB3 /* AppDelegate.m in Sources */,

--- a/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleMenuView.h
+++ b/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleMenuView.h
@@ -29,9 +29,10 @@
 
 @interface MCUIViewLayoutExampleMenuView : UIView
 @property (nonatomic, readonly) UIButton *buttonSetPosition;
-@property (nonatomic, readonly) UIButton *buttonSetPositionSwift;
 @property (nonatomic, readonly) UIButton *buttonSetRelativePosition;
 @property (nonatomic, readonly) UIButton *buttonSetPositionSizeToFit;
 @property (nonatomic, readonly) UIButton *buttonSpecialCases;
 @property (nonatomic, readonly) UIButton *buttonRelativeCenterInParent;
+@property (nonatomic, readonly) UIButton *buttonSetPositionSwift;
+@property (nonatomic, readonly) UIButton *buttonFitSizeSwift;
 @end

--- a/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleMenuView.m
+++ b/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleMenuView.m
@@ -33,11 +33,12 @@
 //------------------------------------------------------------------------------
 @interface MCUIViewLayoutExampleMenuView ()
 @property (nonatomic, readwrite) UIButton *buttonSetPosition;
-@property (nonatomic, readwrite) UIButton *buttonSetPositionSwift;
 @property (nonatomic, readwrite) UIButton *buttonSetRelativePosition;
 @property (nonatomic, readwrite) UIButton *buttonSetPositionSizeToFit;
 @property (nonatomic, readwrite) UIButton *buttonSpecialCases;
 @property (nonatomic, readwrite) UIButton *buttonRelativeCenterInParent;
+@property (nonatomic, readwrite) UIButton *buttonSetPositionSwift;
+@property (nonatomic, readwrite) UIButton *buttonFitSizeSwift;
 @end
 
 //------------------------------------------------------------------------------
@@ -56,12 +57,6 @@
         [self.buttonSetPosition setTitle:@"mc_setPosition" forState:UIControlStateNormal];
         [self.buttonSetPosition sizeToFit];
         [self addSubview:self.buttonSetPosition];
-
-        self.buttonSetPositionSwift = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-        [self.buttonSetPositionSwift setTitle:@"setPosition [Swift]" forState:UIControlStateNormal];
-        [self.buttonSetPositionSwift setTitleColor:[UIColor orangeColor] forState:UIControlStateNormal];
-        [self.buttonSetPositionSwift sizeToFit];
-        [self addSubview:self.buttonSetPositionSwift];
 
         self.buttonSetRelativePosition = [UIButton buttonWithType:UIButtonTypeRoundedRect];
         [self.buttonSetRelativePosition setTitle:@"mc_setPositionRelative" forState:UIControlStateNormal];
@@ -82,6 +77,18 @@
         [self.buttonRelativeCenterInParent setTitle:@"mc_RelativeCenterInParent" forState:UIControlStateNormal];
         [self.buttonRelativeCenterInParent sizeToFit];
         [self addSubview:self.buttonRelativeCenterInParent];
+
+        self.buttonSetPositionSwift = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+        [self.buttonSetPositionSwift setTitle:@"setPosition [Swift]" forState:UIControlStateNormal];
+        [self.buttonSetPositionSwift setTitleColor:[UIColor orangeColor] forState:UIControlStateNormal];
+        [self.buttonSetPositionSwift sizeToFit];
+        [self addSubview:self.buttonSetPositionSwift];
+
+        self.buttonFitSizeSwift = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+        [self.buttonFitSizeSwift setTitle:@"FitSize [Swift]" forState:UIControlStateNormal];
+        [self.buttonFitSizeSwift setTitleColor:[UIColor orangeColor] forState:UIControlStateNormal];
+        [self.buttonFitSizeSwift sizeToFit];
+        [self addSubview:self.buttonFitSizeSwift];
     }
     return self;
 }
@@ -102,11 +109,8 @@
     [super layoutSubviews];
     [self.buttonSetPosition mc_setPosition:MCViewPositionTopHCenter withMargins:UIEdgeInsetsMake(50, 0, 0, 0)];
 
-    [self.buttonSetPositionSwift mc_setRelativePosition:MCViewRelativePositionUnderCentered
-                                                    toView:self.buttonSetPosition withMargins:UIEdgeInsetsZero];
-
     [self.buttonSetRelativePosition mc_setRelativePosition:MCViewRelativePositionUnderCentered
-                                                    toView:self.buttonSetPositionSwift withMargins:UIEdgeInsetsMake(15.0f, 0, 0, 0)];
+                                                    toView:self.buttonSetPosition withMargins:UIEdgeInsetsMake(15.0f, 0, 0, 0)];
 
     [self.buttonSetPositionSizeToFit mc_setRelativePosition:MCViewRelativePositionUnderCentered
                                                      toView:self.buttonSetRelativePosition withMargins:UIEdgeInsetsMake(15.0f, 0, 0, 0)];
@@ -114,6 +118,13 @@
                                              toView:self.buttonSetPositionSizeToFit withMargins:UIEdgeInsetsMake(15.0f, 0, 0, 0)];
     [self.buttonRelativeCenterInParent mc_setRelativePosition:MCViewRelativePositionUnderCentered | MCViewPositionFitWidth
                                                        toView:self.buttonSpecialCases withMargins:UIEdgeInsetsMake(15.0f, 0, 0, 0)];
+
+    // Swift
+    [self.buttonSetPositionSwift mc_setRelativePosition:MCViewRelativePositionUnderCentered | MCViewPositionFitWidth
+                                                 toView:self.buttonRelativeCenterInParent withMargins:UIEdgeInsetsMake(15.0f, 0, 0, 0)];
+
+    [self.buttonFitSizeSwift mc_setRelativePosition:MCViewRelativePositionUnderCentered | MCViewPositionFitWidth
+                                             toView:self.buttonSetPositionSwift withMargins:UIEdgeInsetsMake(15.0f, 0, 0, 0)];
 }
 
 //------------------------------------------------------------------------------

--- a/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleSetPositionFitSize.swift
+++ b/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutExampleSetPositionFitSize.swift
@@ -1,0 +1,84 @@
+// Copyright (c) 2016, Mirego
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// - Neither the name of the Mirego nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+class MCUIViewLayoutExampleFitSize: UIView
+{
+    private let fitSizeLeft30 = UILabel()
+    private let fitSizeCenter30 = UILabel()
+    private let fitSizeRight30 = UILabel()
+
+    private let fitSize50 = UILabel()
+    private let fitSize75 = UILabel()
+    private let fitSize100 = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = .blueColor()
+
+        addLabel(fitSizeLeft30, title: "Left fitSize 33% of parent's width - Lo rem ip sum do lor sit a met, con sec a b c d e f g h i")
+        addLabel(fitSizeCenter30, title: "Center fitSize 33% of parent's width - Lo rem ip sum do lor sit a met, con sec a b c d e f g h i")
+        addLabel(fitSizeRight30, title: "Right fitSize 33% of parent's width - Lo rem ip sum do lor sit a met, con sec a b c d e f g h i")
+        addLabel(fitSize50, title: "fitSize 50% of parent's width - Lo rem ip sum do lor sit a met, con sec")
+        addLabel(fitSize75, title: "fitSize 75% of parent's width - Lo rem ip sum do lor sit a met, con sec")
+        addLabel(fitSize100, title: "fitSize 100% of parent's width - Lo rem ip sum do lor sit a met, con sec")
+
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: "close"))
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let margins = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
+
+        fitSizeLeft30.setPosition(.PositionTopLeft, margins: UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0), fitSize: CGSize(width: frame.width * 0.3333, height: .max))
+        fitSizeCenter30.setRelativePosition(.RelativePositionToTheRightAlignedTop, toView: fitSizeLeft30, fitSize: CGSize(width: frame.width * 0.3333, height: .max))
+        fitSizeRight30.setRelativePosition(.RelativePositionToTheRightAlignedTop, toView: fitSizeCenter30, fitSize: CGSize(width: frame.width * 0.3333, height: .max))
+        fitSize50.setRelativePosition(.RelativePositionUnderAlignedLeft, toView: fitSizeLeft30, margins: margins, fitSize: CGSize(width: frame.width * 0.5, height: .max))
+        fitSize75.setRelativePosition(.RelativePositionUnderAlignedLeft, toView: fitSize50, margins: margins, fitSize: CGSize(width: frame.width * 0.75, height: .max))
+        fitSize100.setRelativePosition(.RelativePositionUnderAlignedLeft, toView: fitSize75, margins: margins, fitSize: CGSize(width: frame.width, height: .max))
+    }
+
+    private func addLabel(label: UILabel, title: String) {
+        label.text = title
+        label.numberOfLines = 0
+        label.sizeToFit()
+        label.layer.borderWidth = 1
+
+        addSubview(label)
+    }
+
+    func close() {
+        removeFromSuperview()
+    }
+}

--- a/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutRootController.m
+++ b/MCUIViewLayoutExample/UIViewLayoutExample/MCUIViewLayoutRootController.m
@@ -70,12 +70,15 @@
 - (void)loadView {
     MCUIViewLayoutExampleMenuView *rootview = [[MCUIViewLayoutExampleMenuView alloc] initWithFrame:[[UIScreen mainScreen] applicationFrame]];
     [rootview.buttonSetPosition addTarget:self action:@selector(showSetPositionExample) forControlEvents:UIControlEventTouchUpInside];
-    [rootview.buttonSetPositionSwift addTarget:self action:@selector(showSetPositionExampleSwift) forControlEvents:UIControlEventTouchUpInside];
-
     [rootview.buttonSetRelativePosition addTarget:self action:@selector(showSetRelativePositionExample) forControlEvents:UIControlEventTouchUpInside];
     [rootview.buttonSetPositionSizeToFit addTarget:self action:@selector(showSetPositionSizeToFitExample) forControlEvents:UIControlEventTouchUpInside];
     [rootview.buttonSpecialCases addTarget:self action:@selector(showSpecialCases) forControlEvents:UIControlEventTouchUpInside];
     [rootview.buttonRelativeCenterInParent addTarget:self action:@selector(showRelativeCenterInParent) forControlEvents:UIControlEventTouchUpInside];
+
+    // Swift
+    [rootview.buttonSetPositionSwift addTarget:self action:@selector(showSetPositionExampleSwift) forControlEvents:UIControlEventTouchUpInside];
+    [rootview.buttonFitSizeSwift addTarget:self action:@selector(showFitSizeExampleSwift) forControlEvents:UIControlEventTouchUpInside];
+
     self.view = rootview;
 }
 
@@ -93,6 +96,12 @@
 
 - (void)showSetPositionExampleSwift {
     UIView *view = [[MCUIViewLayoutExampleSetPositionSwift alloc] initWithFrame:self.view.bounds];
+    view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.view addSubview:view];
+}
+
+- (void)showFitSizeExampleSwift {
+    UIView *view = [[MCUIViewLayoutExampleFitSize alloc] initWithFrame:self.view.bounds];
     view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self.view addSubview:view];
 }


### PR DESCRIPTION
Instead of doing:

```
let labelSize = myLabel.sizeThatFits(CGSize(width: 200, height: .max))
myLabel.setPosition(.PositionTopLeft, size: labelSize)
```

We can do:

```
myLabel.setPosition(.PositionTopLeft, fitSize: CGSize(width: 200, height: .max))
```
